### PR TITLE
Copy composer binary from official Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,11 +49,7 @@ RUN mkdir -p /var/www && \
     rm /etc/php7/php.ini
 
 # INSTALL COMPOSER.
-ARG COMPOSER_HASH=a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-    php -r "if (hash_file('SHA384', 'composer-setup.php') === '${COMPOSER_HASH}') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
-    php composer-setup.php --install-dir=/usr/bin --filename=composer && \
-    php -r "unlink('composer-setup.php');"
+COPY --from=composer:1.10 /usr/bin/composer /usr/bin/composer
 
 # ADD START SCRIPT, SUPERVISOR CONFIG, NGINX CONFIG AND RUN SCRIPTS.
 ADD start.sh /start.sh

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,6 @@ Here are some args
 
 - `NGINX_HTTP_PORT` - HTTP port. Default: `80`.
 - `NGINX_HTTPS_PORT` - HTTPS port. Default: `443`.
-- `COMPOSER_HASH` - Composer hash. Default: `a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1`.
 - `PHP_VERSION` - The PHP version to install. Supports: `7.3`. Default: `7.3`.
 - `ALPINE_VERSION` - The Alpine version. Supports: `3.9`. Default: `3.9`.
 


### PR DESCRIPTION
This removes the hassle of dealing with the composer hash when building the docker image.
This way of getting the composer binary seems as reliable as the previous way. 